### PR TITLE
BUG: Prevent repeated calls to slicer.vtkMRMLModelHierarchyNode()

### DIFF
--- a/PCampReview.py
+++ b/PCampReview.py
@@ -709,7 +709,7 @@ class PCampReviewWidget:
 
       for n in xrange(numNodes):
         node = slicer.mrmlScene.GetNthNodeByClass( n, "vtkMRMLModelHierarchyNode" )
-        if node.GetName() == 'PCampReview'+refLongName:
+        if node.GetName() == 'PCampReview-'+refLongName:
           outHierarchy = node
           break
 


### PR DESCRIPTION
The missing dash is causing the code to not find the existing model hierarchy node so every time a new one gets created.  I think this is a bug.
