### PR TITLE
ENH: set master and merge volumes at once

### DIFF
--- a/PCampReview.py
+++ b/PCampReview.py
@@ -1285,8 +1285,7 @@ class PCampReviewWidget:
       self.rows = 4
     self.cols = math.ceil(nVolumeNodes/self.rows)
 
-    self.editorWidget.setMasterNode(self.volumeNodes[0])
-    self.editorWidget.setMergeNode(self.seriesMap[str(ref)]['Label'])
+    self.editorWidget.helper.setVolumes(self.volumeNodes[0], self.seriesMap[str(ref)]['Label'])
 
     self.cvLogic.viewerPerVolume(self.volumeNodes, background=self.volumeNodes[0], label=refLabel,layout=[self.rows,self.cols],viewNames=self.viewNames)
     self.cvLogic.rotateToVolumePlanes(self.volumeNodes[0])


### PR DESCRIPTION
This avoids the check for the node name in set merge node, which is currently
not working as expected, and as a result gets rid of the Editor popup window
while setting the merge node (see proposed soultion https://github.com/Slicer/Slicer/pull/263).

Thanks to @rweiss42 for investigating the issue, and to @pieper for the
setVolumes() hint!
