### PR TITLE
Fix cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_PYTHON_SCRIPTS
   )
 
 set(MODULE_PYTHON_RESOURCES
+  Resources/Colors/PCampReviewColors.csv
   )
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,21 @@
 cmake_minimum_required(VERSION 2.8.7)
 
 #-----------------------------------------------------------------------------
-if(NOT Slicer_SOURCE_DIR)
-  set(EXTENSION_NAME PCampReview)
-  set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/4.2/Extensions/PCampReview")
-  set(EXTENSION_CATEGORY "Examples")
-  set(EXTENSION_CONTRIBUTORS "Jean-Christophe Fillion-Robin (Kitware), Steve Pieper (Isomics)")
-  set(EXTENSION_DESCRIPTION "This is an example of extension bundling a scripted loadable module")
-  set(EXTENSION_ICONURL "http://viewvc.slicer.org/viewvc.cgi/Slicer4/trunk/Extensions/Testing/PCampReview/Resources/Icons/PCampReview.png?revision=19437&view=co")
-  set(EXTENSION_SCREENSHOTURLS "http://wiki.slicer.org/slicerWiki/images/e/e2/Slicer-r19441-PCampReview-screenshot.png")
-endif()
+set(EXTENSION_NAME PCampReview)
+set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/4.2/Extensions/PCampReview")
+set(EXTENSION_CATEGORY "Examples")
+set(EXTENSION_CONTRIBUTORS "Jean-Christophe Fillion-Robin (Kitware), Steve Pieper (Isomics)")
+set(EXTENSION_DESCRIPTION "This is an example of extension bundling a scripted loadable module")
+set(EXTENSION_ICONURL "http://viewvc.slicer.org/viewvc.cgi/Slicer4/trunk/Extensions/Testing/PCampReview/Resources/Icons/PCampReview.png?revision=19437&view=co")
+set(EXTENSION_SCREENSHOTURLS "http://wiki.slicer.org/slicerWiki/images/e/e2/Slicer-r19441-PCampReview-screenshot.png")
+
+
+#-----------------------------------------------------------------------------
+find_package(Slicer REQUIRED)
+include(${Slicer_USE_FILE})
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME PCampReview)
-
-#-----------------------------------------------------------------------------
-if(NOT Slicer_SOURCE_DIR)
-  find_package(Slicer REQUIRED)
-  include(${Slicer_USE_FILE})
-endif()
 
 #-----------------------------------------------------------------------------
 set(MODULE_PYTHON_SCRIPTS
@@ -33,6 +30,7 @@ slicerMacroBuildScriptedModule(
   NAME ${MODULE_NAME}
   SCRIPTS ${MODULE_PYTHON_SCRIPTS} 
   RESOURCES ${MODULE_PYTHON_RESOURCES}
+  WITH_GENERIC_TESTS
   )
 
 #-----------------------------------------------------------------------------
@@ -47,6 +45,4 @@ if(BUILD_TESTING)
 endif()
 
 #-----------------------------------------------------------------------------
-if(NOT Slicer_SOURCE_DIR)
-  include(${Slicer_EXTENSION_CPACK})
-endif()
+include(${Slicer_EXTENSION_CPACK})

--- a/PCampReview.py
+++ b/PCampReview.py
@@ -11,8 +11,6 @@ from EditorLib import EditorLib
 import SimpleITK as sitk
 import sitkUtils
 
-import PCampReviewLib
-
 #
 # PCampReview
 #

--- a/Testing/Python/CMakeLists.txt
+++ b/Testing/Python/CMakeLists.txt
@@ -1,15 +1,3 @@
 
 #-----------------------------------------------------------------------------
-set(KIT_UNITTEST_SCRIPTS)
-SlicerMacroConfigureGenericPythonModuleTests("${EXTENSION_NAME}" KIT_UNITTEST_SCRIPTS)
-
-#-----------------------------------------------------------------------------
-foreach(script_name ${KIT_UNITTEST_SCRIPTS})
-  slicer_add_python_unittest(
-    SCRIPT ${script_name}
-    SLICER_ARGS --no-main-window --disable-cli-modules --disable-loadable-modules
-                --additional-module-path ${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
-    TESTNAME_PREFIX nomainwindow_
-    )
-endforeach()
-
+#slicer_add_python_unittest(SCRIPT ${MODULE_NAME}ModuleTest.py)


### PR DESCRIPTION
- Ensure PCampReviewLib files are compiled and packaged
- Simplify CMakeLists.txt

Note that `PCampReviewPreprocessor.py` and files in `Utils` directory are not packaged yet.
