### PR TITLE
BUG: If PCampReview/InputLocation is not set, checkAndSetLUT will fail

### DIFF
--- a/PCampReview.py
+++ b/PCampReview.py
@@ -527,6 +527,9 @@ class PCampReviewWidget:
 
   def checkAndSetLUT(self):
     
+    if (self.settings.value('PCampReview/InputLocation') == None):
+      return
+    
     lookupTableLoc = self.settings.value('PCampReview/InputLocation') + os.sep + 'SETTINGS' + os.sep + self.settings.value('PCampReview/InputLocation').split(os.sep)[-1] + '-LUT.csv'
     print('Checking for lookup table at : ' + lookupTableLoc)
     self.colorFile = ""

--- a/PCampReview.py
+++ b/PCampReview.py
@@ -527,23 +527,21 @@ class PCampReviewWidget:
 
   def checkAndSetLUT(self):
     
-    if (self.settings.value('PCampReview/InputLocation') == None):
-      return
-    
-    lookupTableLoc = self.settings.value('PCampReview/InputLocation') + os.sep + 'SETTINGS' + os.sep + self.settings.value('PCampReview/InputLocation').split(os.sep)[-1] + '-LUT.csv'
-    print('Checking for lookup table at : ' + lookupTableLoc)
-    self.colorFile = ""
-    if os.path.isfile(lookupTableLoc):
-      # use custom color table
-      self.colorFile = lookupTableLoc
-      self.customLUTLabel.text = 'Project-Specific LUT Found'
-    else:   
-      # use the module default color table 
-      moduleName="PCampReview"
-      modulePath = eval('slicer.modules.%s.path' % moduleName.lower()).replace(moduleName+".py","")
-      self.colorFile = modulePath + "Resources/Colors/PCampReviewColors.csv"
-      self.customLUTLabel.text = 'Using Default LUT'
-      
+    # Default to module color table 
+    moduleName="PCampReview"
+    modulePath = eval('slicer.modules.%s.path' % moduleName.lower()).replace(moduleName+".py","")
+    self.colorFile = modulePath + "Resources/Colors/PCampReviewColors.csv"
+    self.customLUTLabel.text = 'Using Default LUT'
+
+    # Check for custom LUT
+    if (self.settings.value('PCampReview/InputLocation') != None):
+      lookupTableLoc = self.settings.value('PCampReview/InputLocation') + os.sep + 'SETTINGS' + os.sep + self.settings.value('PCampReview/InputLocation').split(os.sep)[-1] + '-LUT.csv'
+      print('Checking for lookup table at : ' + lookupTableLoc)
+      if os.path.isfile(lookupTableLoc):
+        # use custom color table
+        self.colorFile = lookupTableLoc
+        self.customLUTLabel.text = 'Project-Specific LUT Found'
+
     # setup the color table
     self.PCampReviewColorNode = slicer.vtkMRMLColorTableNode()
     colorNode = self.PCampReviewColorNode


### PR DESCRIPTION
Since checkAndSetLUT is called in setup(), if you have never run PCampReview before and thus PCampReview/InputLocation is not set, setup will fail when constructing the lookupTableLoc string.

Since the overall handling of lookup tables will be re-visited in the near-ish future and checkAndSetLUT will probably go away, I think this fix is ok for now.  If you don't have an InputLocation set you're not going to get terribly far in the program anyway...
