### PR TITLE
ENH: Adding label that indicates what Data Dir you are in during step 2

### DIFF
--- a/PCampReview.py
+++ b/PCampReview.py
@@ -255,6 +255,9 @@ class PCampReviewWidget(ScriptedLoadableModuleWidget):
     self.studiesView.setModel(self.studiesModel)
     self.studiesView.setEditTriggers(qt.QAbstractItemView.NoEditTriggers)
     self.studiesView.connect('clicked(QModelIndex)', self.studySelected)
+    self.dataDirLabel = qt.QLabel()
+    self.dataDirLabel.text = "Current Data Dir: "
+    self.studySelectionGroupBoxLayout.addRow(self.dataDirLabel)
     self.studySelectionGroupBoxLayout.addWidget(self.studiesView)
 
     #
@@ -1045,6 +1048,7 @@ class PCampReviewWidget(ScriptedLoadableModuleWidget):
     studyDirs = []
     # get list of studies
     inputDir = self.settings.value('PCampReview/InputLocation')
+    self.dataDirLabel.text = "Current Data Dir: " + str(self.settings.value('PCampReview/InputLocation') +"\n")
     if not os.path.exists(inputDir):
       return
 


### PR DESCRIPTION
Since we're bypassing setting the data directory if there is something already set, I figured it would be good to have some indication of where you are

![screen shot 2015-06-26 at 12 20 47 pm](https://cloud.githubusercontent.com/assets/9009739/8383177/cf1591de-1bfd-11e5-9e56-fb0be963d081.png)
