### PR TITLE
Using separate class for temporary DICOMDatabase without touching Slicer specific db, processing window always on top

### DIFF
--- a/mpReview.py
+++ b/mpReview.py
@@ -17,7 +17,7 @@ from qSlicerMultiVolumeExplorerModuleWidget import qSlicerMultiVolumeExplorerSim
 from qSlicerMultiVolumeExplorerModuleHelper import qSlicerMultiVolumeExplorerModuleHelper as MVHelper
 
 
-class mpReview(ScriptedLoadableModule):
+class mpReview(ScriptedLoadableModule, ModuleWidgetMixin):
 
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
@@ -830,7 +830,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
         outHierarchy.SetName( 'mpReview-'+refLongName )
         slicer.mrmlScene.AddNode( outHierarchy )
 
-      progress = slicer.util.createProgressDialog(maximum=len(labelNodes))
+      progress = self.createProgressDialog(maximum=len(labelNodes))
       step = 0
       for label in labelNodes.values():
         labelName =  label.GetName().split(':')[1]
@@ -1074,7 +1074,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.studyItems = []
     self.seriesModel.clear()
     dirs = self.logic.getStudyNames(self.inputDataDir)
-    progress = slicer.util.createProgressDialog(maximum=len(dirs))
+    progress = self.createProgressDialog(maximum=len(dirs))
     for studyIndex, studyName in enumerate(dirs, start=1):
       if os.path.isdir(os.path.join(self.inputDataDir, studyName)) and studyName != 'SETTINGS':
         sItem = qt.QStandardItem(studyName)
@@ -1092,7 +1092,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
 
   def invokePreProcessing(self, outputDirectory):
     self.mpReviewPreprocessorLogic = mpReviewPreprocessorLogic()
-    self.progress = slicer.util.createProgressDialog()
+    self.progress = self.createProgressDialog()
     self.progress.canceled.connect(lambda : self.mpReviewPreprocessorLogic.cancelProcess())
     self.mpReviewPreprocessorLogic.importStudy(self.inputDataDir, progressCallback=self.updateProgressBar)
     success = False
@@ -1143,7 +1143,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
 
     self.resourcesDir = os.path.join(self.inputDataDir, self.selectedStudyName, 'RESOURCES')
 
-    self.progress = slicer.util.createProgressDialog(maximum=len(os.listdir(self.resourcesDir)))
+    self.progress = self.createProgressDialog(maximum=len(os.listdir(self.resourcesDir)))
     self.seriesMap, metaFile = self.logic.loadMpReviewProcessedData(self.resourcesDir,
                                                                     updateProgressCallback=self.updateProgressBar)
     self.informationWatchBox.sourceFile = metaFile
@@ -1190,7 +1190,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.refSelectorIgnoreUpdates = True
 
     # Loading progress indicator
-    progress = slicer.util.createProgressDialog(maximum=len(checkedItems))
+    progress = self.createProgressDialog(maximum=len(checkedItems))
     nLoaded = 0
 
     # iterate over all selected items and add them to the reference selector
@@ -1672,7 +1672,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     emptyDstLabel = []
 
     # Do the resamples
-    progress = slicer.util.createProgressDialog(maximum=len(propagateInto))
+    progress = self.createProgressDialog(maximum=len(propagateInto))
     nProcessed = 0
     for dstSeries in propagateInto:
       labelName = self.seriesMap[dstSeries]['ShortName']+'-'+selectedStructure+'-label'

--- a/mpReviewPreprocessor.py
+++ b/mpReviewPreprocessor.py
@@ -66,7 +66,7 @@ class mpReviewPreprocessorWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin
 
   def onRunClicked(self):
     logic = mpReviewPreprocessorLogic()
-    self.progress = slicer.util.createProgressDialog()
+    self.progress = self.createProgressDialog()
     self.progress.canceled.connect(lambda: logic.cancelProcess())
     logic.importStudy(self.inputDirButton.directory, progressCallback=self.updateProgressBar)
     logic.convertData(self.outputDirButton.directory, copyDICOM=self.copyDICOMButton.checked,


### PR DESCRIPTION
* fixes #146 
* fixes #154 

* depends on SlicerProstate/SlicerProstate/pull/44