### PR TITLE
BUG: Changes in Slicer Core caused mpReviewPreprocessor to fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,4 +56,6 @@ if(BUILD_TESTING)
 endif()
 
 #-----------------------------------------------------------------------------
+
+include(${Slicer_EXTENSION_GENERATE_CONFIG})
 include(${Slicer_EXTENSION_CPACK})

--- a/mpReviewPreprocessor.py
+++ b/mpReviewPreprocessor.py
@@ -122,7 +122,7 @@ class mpReviewPreprocessorLogic(ScriptedLoadableModuleLogic, ModuleLogicMixin):
 
   def importAndProcessData(self, inputDir, outputDir, copyDICOM, progressCallback=None):
     self.canceled = False
-    with TemporaryDICOMDatabase(os.path.join(self.dataDir, "CtkDICOMDatabase"), True) as db:
+    with TemporaryDICOMDatabase(os.path.join(self.dataDir, "CtkDICOMDatabase")) as db:
       self._importStudy(inputDir, progressCallback)
       success = self._processData(outputDir, copyDICOM, progressCallback)
     return success


### PR DESCRIPTION
* also generating extension config

for the reference : https://github.com/Slicer/Slicer/commit/fce63b47161baecc320672e93b879c0e08d3ed9a