### PR TITLE
Multiple server feature json

### DIFF
--- a/Resources/mpReview_local_configuration.json
+++ b/Resources/mpReview_local_configuration.json
@@ -3,8 +3,8 @@
 	"database_type": "local",
 	"remote_database_configuration": 
 		{
-			"database_type": "google", 
 			"project_id":"idc-external-018",
+			"location_id":"us-central1",
 			"dataset_id":"pw39",
 			"dicomstore":"pw39", 
 			"server_url":""
@@ -13,11 +13,6 @@
 		{
 			"StudyInstanceUID_list": "", 
 			"SeriesInstanceUID_list": ""
-		},
-	"parameters": 
-		{
-			"load_4d_series": "0",
-			"review_segmentations": "0"
 		},
 	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
 	

--- a/Resources/mpReview_local_configuration.json
+++ b/Resources/mpReview_local_configuration.json
@@ -1,0 +1,26 @@
+{
+	"username": "deepa", 
+	"database_type": "local",
+	"remote_database_configuration": 
+		{
+			"database_type": "google", 
+			"project_id":"idc-external-018",
+			"dataset_id":"pw39",
+			"dicomstore":"pw39", 
+			"server_url":""
+		},
+	"uids":
+		{
+			"StudyInstanceUID_list": "", 
+			"SeriesInstanceUID_list": ""
+		},
+	"parameters": 
+		{
+			"load_4d_series": "0",
+			"review_segmentations": "0"
+		},
+	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
+	
+} 
+
+

--- a/Resources/mpReview_remote_gcp_configuration.json
+++ b/Resources/mpReview_remote_gcp_configuration.json
@@ -14,11 +14,6 @@
 			"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
 			"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
 		},
-	"parameters": 
-		{
-			"load_4d_series": "0",
-			"review_segmentations": "0"
-		},
 	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
 	
 } 

--- a/Resources/mpReview_remote_gcp_configuration.json
+++ b/Resources/mpReview_remote_gcp_configuration.json
@@ -1,0 +1,26 @@
+{
+	"username": "deepa", 
+	"database_type": "remote",
+	"remote_database_configuration": 
+		{
+			"project_id":"idc-external-018",
+			"location_id":"us-central1",
+			"dataset_id":"pw39",
+			"dicomstore_id":"pw39", 
+			"other_server_url":""
+		},
+	"uids":
+		{
+			"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
+			"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
+		},
+	"parameters": 
+		{
+			"load_4d_series": "0",
+			"review_segmentations": "0"
+		},
+	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
+	
+} 
+
+

--- a/Resources/mpReview_remote_gcp_configuration_hierarchy.json
+++ b/Resources/mpReview_remote_gcp_configuration_hierarchy.json
@@ -1,0 +1,28 @@
+{
+	"username": "deepa", 
+	"database_type": "remote",
+	"remote_database_configuration": 
+		{
+			"project_id":"idc-external-018",
+			"location_id":"us-central1",
+			"dataset_id":"pw39",
+			"dicomstore_id":"pw39", 
+			"other_server_url":""
+		},
+	"uids":
+		{
+			[
+				{
+					"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
+					"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"] 
+				}, 
+				{
+					"StudyInstanceUID_list": [], 
+					"SeriesInstanceUID_list": []
+			] 
+		},
+	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
+	
+} 
+
+

--- a/Resources/mpReview_remote_gcp_configuration_hierarchy.json
+++ b/Resources/mpReview_remote_gcp_configuration_hierarchy.json
@@ -9,20 +9,17 @@
 			"dicomstore_id":"pw39", 
 			"other_server_url":""
 		},
-	"uids":
-		{
-			[
-				{
-					"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
-					"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"] 
-				}, 
-				{
-					"StudyInstanceUID_list": [], 
-					"SeriesInstanceUID_list": []
-			] 
-		},
+
+    "uids":[
+        {
+            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133",
+            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
+        },
+        {
+            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664",
+            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.609837242670719860929372097937"]
+        }
+	],
 	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
 	
 } 
-
-

--- a/Resources/mpReview_remote_kaapana_configuration.json
+++ b/Resources/mpReview_remote_kaapana_configuration.json
@@ -1,0 +1,21 @@
+{
+	"username": "deepa", 
+	"database_type": "remote",
+	"remote_database_configuration": 
+		{
+			"project_id":"",
+			"location_id":"",
+			"dataset_id":"",
+			"dicomstore_id":"", 
+			"other_server_url":"http://dcm4chee-service.store:8080/dcm4chee-arc/aets/KAAPANA/rs"
+		},
+	"uids":
+		{
+			"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
+			"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
+		},
+	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
+	
+} 
+
+

--- a/mpReview.py
+++ b/mpReview.py
@@ -48,6 +48,7 @@ class GoogleCloudPlatform(object):
 
   def datasets(self, project):
     return sorted(self.gcloud(f"--project {project} healthcare datasets list --format=value(ID,LOCATION)").split("\n"), key=str.lower)
+    # return sorted(self.gcloud(f"--project {project} healthcare datasets list --format=value(ID)").split("\n"), key=str.lower)
 
   def dicomStores(self, project, dataset):
     return sorted(self.gcloud(f"--project {project} healthcare dicom-stores list --dataset {dataset} --format=value(ID)").split("\n"), key=str.lower)
@@ -137,6 +138,10 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.tempDir = os.path.join(slicer.app.temporaryPath, 'mpReview-tmp')
     self.logic.createDirectory(self.tempDir, message='Temporary directory location: ' + self.tempDir)
     self.modulePath = os.path.dirname(slicer.util.modulePath(self.moduleName))
+    
+    # self.paramJSONFile = os.path.join(self.resourcesPath, "mpReview_local_configuration.json")
+    self.paramJSONFile = os.path.join(self.resourcesPath, "mpReview_remote_gcp_configuration.json")
+    self.parseJSON()
 
   def getAllSliceWidgets(self):
     widgetNames = self.layoutManager.sliceViewNames()
@@ -252,6 +257,8 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.currentTabIndex = 0
 
     self.checkAndSetLUT() # I added 
+    
+    self.parseJSONDatabase()
 
   def setupInformationFrame(self):
 
@@ -350,6 +357,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
       
       self.datasetSelectorCombobox.setEditable(True)
       dataset_list = self.gcp.datasets(self.project)
+      # dataset_list = [f[0] for f.split() in dataset_list]
       self.datasetCompleter = qt.QCompleter(dataset_list)
       self.datasetCompleter.setCaseSensitivity(0)
       self.datasetCompleter.setCompletionColumn(0)
@@ -373,6 +381,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
 
   def onDICOMStoreSelected(self):
     currentText = self.dicomStoreSelectorCombobox.currentText
+    print("in onDICOMStoreSelected. currentText: " + str(currentText)) 
     if currentText != "":
       self.dicomStore = currentText.split()[0]
       # populate the server url here
@@ -400,7 +409,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
   def checkIfLocationExists(self):
     
     locationList = self.gcp.locations()
-    if not self.location in locationlist: 
+    if not self.location in locationList: 
       return False
     else:
       return True 
@@ -894,7 +903,15 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
   #     self.parameters['ResultsLocation'] = resultsLocation
   #   '''
 
+
   def checkAndSetLUT(self):
+    """This function parses the terminology file""" 
+     
+    self.parseJSONTerminology()
+
+
+  def checkAndSetLUT_old(self):
+    
     # Default to module color table
     self.terminologyFile = os.path.join(self.resourcesPath, "SegmentationCategoryTypeModifier-mpReview.json")
     # print ('self.terminologyFile: ' + str(self.terminologyFile))
@@ -1354,7 +1371,7 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
         print('Unable to create DICOM database: ' + databaseDirectory)
     
     # If local was clicked, updateStudyTable 
-    if self.selectLocalDatabaseButton.isChecked():
+    if self.selectLocalDatabaseButton.isChecked() or self.jsonDatabaseType == "local":
       # disable the GCP project etc selectors and server url and ok button 
       self.updateSelectorAvailability(set=False)
       self.selectDatabaseOKButton.setEnabled(False)
@@ -1399,7 +1416,6 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.studiesMap = {} 
     ## self.getStudyNamesRemoteDatabase()    # 5-26-22  
     self.fillStudyTableRemoteDatabase()
-
     # update the availability of the next tab 
     self.updateStudiesAndSeriesTabAvailability()
     
@@ -1712,7 +1728,16 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     self.studyItems = [] 
     self.studiesModel.clear()
     self.seriesModel.clear()
-    self.studiesMap = self.getStudyNamesRemoteDatabase()
+    
+    self.parseJSONUID_list()
+    
+    # If json used, check for existence of UIDS 
+    if ("uids" in self.paramJSON.keys()) and ("StudyInstanceUID_list" in self.jsonUIDSConfiguration.keys()):
+      self.studiesMap = self.parseJSONGetStudyNamesRemoteDatabase() 
+    # Else if json not used, fill normally 
+    else: 
+      self.studiesMap = self.getStudyNamesRemoteDatabase()
+      
     self.setStudiesView()
     
   def setStudiesView(self):
@@ -1782,9 +1807,21 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
     if (self.selectLocalDatabaseButton.isChecked()):
       self.updateSeriesTable()
     elif (self.selectRemoteDatabaseButton.isChecked()):
-      self.updateSeriesTableRemote()
+      # self.updateSeriesTableRemote()
+      self.parseJSONUID_list()
+      # If json used, check for existence of UIDS 
+      if ("uids" in self.paramJSON.keys()) and ("SeriesInstanceUID_list" in self.jsonUIDSConfiguration.keys()):
+        self.parseJSONGetSeriesNamesRemoteDatabase() 
+      else: 
+        self.updateSeriesTableRemote()
     elif (self.selectOtherRemoteDatabaseButton.isChecked()):
-      self.updateSeriesTableRemote()
+      # self.updateSeriesTableRemote()
+      self.parseJSONUID_list()
+      if ("uids" in self.paramJSON.keys()) and ("SeriesInstanceUID_list" in self.jsonUIDSConfiguration.keys()):
+        self.parseJSONGetSeriesNamesRemoteDatabase() 
+      else: 
+        self.updateSeriesTableRemote()
+      
 
     self.selectAllSeriesButton.setEnabled(True)
     self.deselectAllSeriesButton.setEnabled(True)
@@ -2464,6 +2501,296 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
   # Gets triggered on a click in the structures table
   def onStructureClicked(self, segmentID):
     self.labelMapVisibilityButton.checked = False
+    
+    
+  def parseJSON(self):
+    """Read in the JSON file that parameterizes mpReview"""
+    # later this JSON file will be passed in the slicer startup script 
+    
+    with open(self.paramJSONFile, 'r') as f:
+      self.paramJSON = json.load(f)
+      print(self.paramJSON)
+    
+  def parseJSONDatabase(self):
+    """Parses the type of database - local or remote """
+    
+    # check if database_type exists 
+    if "database_type" in self.paramJSON.keys():
+      
+      print('database is specified in the json file')
+      self.jsonDatabaseType = self.paramJSON['database_type']
+      
+      if self.jsonDatabaseType == "local":
+        # set 'local' button to pressed 
+        # self.selectLocalDatabaseButton.isChecked()
+        self.selectLocalDatabaseButton.setChecked(True)
+        # run this to setup the study table 
+        self.checkWhichDatabaseSelected()
+        self.tabWidget.setCurrentIndex(1)
+        
+      elif self.jsonDatabaseType == "remote": 
+        # set 'use GCP remote server' button to pressed 
+        self.selectRemoteDatabaseButton.setChecked(True)
+        # self.checkWhichDatabaseSelected() 
+        self.setTabsEnabled([1], False)
+        self.setupGoogleCloudPlatform()
+        self.selectDatabaseOKButton.setEnabled(True)
+        self.updateSelectorAvailability(set=True)
+        self.selectOtherRemoteDatabaseOKButton.setEnabled(False)
+        
+        self.parseJSONRemoteGCP()
+    
+    return
+  
+  def parseJSONRemoteGCP(self):
+    """Parses the fields necessary for remote GCP server"""
+    
+    if self.jsonDatabaseType == "remote": 
+      
+      if "remote_database_configuration" in self.paramJSON.keys(): 
+        print ("parsing json for remote gcp configuration")
+        self.jsonRemoteDatabaseConfiguration = self.paramJSON['remote_database_configuration']
+        # if "database_type" in self.jsonRemoteDatabaseConfiguration.keys():
+          # self.jsonRemoteDatabaseConfigurationDatabaseType = self.jsonRemoteDatabaseConfiguration["database_type"]
+          # if (self.jsonRemoteDatabaseConfigurationDatabaseType == "google"): 
+        
+        if "project_id" in self.jsonRemoteDatabaseConfiguration.keys(): 
+          self.jsonRemoteDatabaseConfigurationProject = self.jsonRemoteDatabaseConfiguration["project_id"]
+          self.parseJSONRemoteGCPCheckExistence(field_to_check="project")
+        if "location_id" in self.jsonRemoteDatabaseConfiguration.keys(): 
+          self.jsonRemoteDatabaseConfigurationLocation = self.jsonRemoteDatabaseConfiguration["location_id"]
+          self.parseJSONRemoteGCPCheckExistence(field_to_check="location")
+        if "dataset_id" in self.jsonRemoteDatabaseConfiguration.keys(): 
+          self.jsonRemoteDatabaseConfigurationDataset = self.jsonRemoteDatabaseConfiguration["dataset_id"]
+          self.parseJSONRemoteGCPCheckExistence(field_to_check="dataset")
+        if "dicomstore_id" in self.jsonRemoteDatabaseConfiguration.keys(): 
+          self.jsonRemoteDatabaseConfigurationDicomstore = self.jsonRemoteDatabaseConfiguration["dicomstore_id"]
+          self.parseJSONRemoteGCPCheckExistence(field_to_check="dicomstore")
+
+    return  
+  
+  def parseJSONRemoteGCPCheckExistence(self, field_to_check):
+    """Check existence of project, location, dataset, or DICOM datastore"""
+    
+    if field_to_check == "project": 
+      self.project = self.jsonRemoteDatabaseConfiguration["project_id"]
+      project_exists = self.checkIfProjectExists()
+      if project_exists: 
+        # set in the dropdown menu
+        self.projectSelectorCombobox.currentText = self.project
+        self.onProjectSelected()
+      else: 
+        # popup warning 
+        print("project " + str(self.project) + " does not exist for the user, please select a project from the dropdown menu")
+
+        
+    elif field_to_check == "location": 
+      self.location = self.jsonRemoteDatabaseConfiguration["location_id"]
+      location_exists = self.checkIfLocationExists()
+      if not location_exists: 
+        # popup warning 
+        print("location " + str(self.location) + " is not correct for this dataset, please check your config file")
+      
+      
+    elif field_to_check == "dataset":
+      self.dataset = self.jsonRemoteDatabaseConfiguration["dataset_id"] 
+      # + ' ' + self.jsonRemoteDatabaseConfiguration["location_id"]
+      dataset_exists = self.checkIfDatasetExists()
+      if dataset_exists: 
+        # set in the dropdown menu 
+        self.datasetSelectorCombobox.currentText = self.dataset + "\t" + self.jsonRemoteDatabaseConfiguration["location_id"]
+        self.onDatasetSelected()
+      else:  
+        # popup warning 
+        print("dataset " + str(self.dataset) + " does not exist in the project selected, please select a dataset from the dropdown menu")
+        
+        
+    elif field_to_check == "dicomstore":
+      self.dicomStore = self.jsonRemoteDatabaseConfiguration["dicomstore_id"]
+      dicomstore_exists = self.checkIfDicomStoreExists()
+      if dicomstore_exists: 
+        # set in the dropdown menu 
+        self.dicomStoreSelectorCombobox.currentText = self.dicomStore 
+        print('dicomstore currentText: ' + str(self.dicomStoreSelectorCombobox.currentText))
+        self.onDICOMStoreSelected()
+       
+      else: 
+        # popup warning 
+        print("dicomstore " + str(self.dicomStore) + " does not exist in the dataset selected, please select a dicomstore from the dropdown menu")
+        
+    else: 
+      print("Field " + str(field_to_check) + " does not exist.")    
+    return  
+  
+  
+  def parseJSONUID_list(self):
+    """This parses the json file for the StudyInstanceUID_list and SeriesInstanceUID_list"""
+    
+    # First make sure it's remote 
+    if self.jsonDatabaseType == "remote":
+      
+      # Then check for uids field existence 
+      if "uids" in self.paramJSON.keys(): 
+        self.jsonUIDSConfiguration = self.paramJSON['uids']
+        if "StudyInstanceUID_list" in self.jsonUIDSConfiguration.keys(): 
+          self.jsonUIDSStudy = self.jsonUIDSConfiguration["StudyInstanceUID_list"]
+        if "SeriesInstanceUID_list" in self.jsonUIDSConfiguration.keys(): 
+          self.jsonUIDSSeries = self.jsonUIDSConfiguration["SeriesInstanceUID_list"]
+     
+    return 
+  
+
+  
+  def parseJSONGetStudyNamesRemoteDatabase(self):
+    """This updates the study table according to the StudyUID_list provided in the json file"""
+    
+    print ('********** Getting the studies to update the study names *******')
+    
+    # For each study in StudyInstanceUID_list, check if it exists in the dicom store 
+    studies = [] 
+    for studyUID in self.jsonUIDSStudy:
+      study = self.DICOMwebClient.search_for_studies(search_filters={'StudyInstanceUID': studyUID})
+      if (study): 
+        studies.append(study[0])
+        
+    print('studies: ' + str(studies))
+    # later popup warning
+    if not studies: 
+      print('The uids provided in the json for StudyInstanceUID_list do not exist in the server, or are not valid')
+      
+    
+    # Iterate over each patient ID, get the appropriate list of studies 
+    studiesMap = {} 
+    ShortNames = [] 
+    for study in studies: 
+      patient = self.getTagValue(study, 'PatientID')
+      studyDate = self.getTagValue(study, 'StudyDate')
+      ShortName = patient + '_' + studyDate
+      studyUID = self.getTagValue(study, 'StudyInstanceUID')
+      studiesMap[studyUID] = {'ShortName': ShortName}
+      studiesMap[studyUID]['LongName'] = '' # can remove LongName later
+      studiesMap[studyUID]['StudyInstanceUID'] = studyUID
+      ShortNames.append(ShortName)
+    
+    # order the values
+    studiesMap = {k: v for k, v in sorted(studiesMap.items(), key=lambda item: item[1]['ShortName'])}
+    
+    self.studiesMap = studiesMap 
+        
+    return studiesMap 
+    
+    return 
+  
+  def parseJSONGetSeriesNamesRemoteDatabase(self):
+    """This updates the series table according to the SeriesUID_list provided in the json file"""
+    
+    self.seriesItems = []
+    self.seriesUIDs = []
+    self.seriesModel.clear()
+    
+    # Get the studyInstanceUID of the study selected 
+    studyInstanceUID = self.selectedStudyNumber
+    
+    # Get the series 
+    print ('******** Getting the series to update the series table remote ******')
+    
+    seriesList = [] 
+    for seriesUID in self.jsonUIDSSeries:
+      # seriesList = self.DICOMwebClient.search_for_series(studyInstanceUID)
+      series = self.DICOMwebClient.search_for_series(search_filters={'StudyInstanceUID': studyInstanceUID, 'SeriesInstanceUID': seriesUID})
+      if (series): 
+        seriesList.append(series[0])
+        
+    if not seriesList: 
+      print('The uids provided in the json for SeriesInstanceUID_list do not exist in the server, or are not valid')
+    
+    self.seriesList = seriesList 
+
+    seriesMap = {} 
+    for series in seriesList: 
+      # need to get metadata
+      seriesInstanceUID = self.getTagValue(series, 'SeriesInstanceUID')
+      metadata = self.DICOMwebClient.retrieve_series_metadata(study_instance_uid=studyInstanceUID,
+                                                              series_instance_uid=seriesInstanceUID
+                                                              )
+
+      try:
+        seriesNumber = str(self.getTagValue(metadata[0], 'SeriesNumber')) 
+      except: 
+        seriesNumber = -1 
+
+      try:
+        seriesDescription = self.getTagValue(series, 'SeriesDescription')
+      except: 
+        seriesDescription = "" 
+
+      if (seriesNumber != -1 and seriesDescription):
+        seriesMap[seriesInstanceUID] = {'ShortName':  str(seriesNumber) + ' : ' + seriesDescription}
+      elif (seriesNumber == -1 and seriesDescription):
+        seriesMap[seriesInstanceUID] = {'ShortName': '[no SeriesNumber] ' + seriesDescription}
+      elif (seriesDescription == ""):
+        seriesMap[seriesInstanceUID] = {'ShortName': str(seriesNumber) + ' [no SeriesDescription]'}
+      else: 
+        seriesMap[seriesInstanceUID] = {'ShortName': '[no SeriesNumber or SeriesDescription]'}
+
+      # add the Modality in
+      modality = self.getTagValue(metadata[0], 'Modality')
+      seriesMap[seriesInstanceUID]['Modality'] = modality
+  
+    self.seriesMap = seriesMap 
+    
+    self.fillSeriesTable()
+        
+    self.updateSegmentationTabAvailability()  
+     
+    return  
+  
+    
+  def parseJSONTerminology(self):
+    """Parse the terminology from the json file"""
+    
+    # check if "terminology" is a key in the json file
+    if "terminology" in self.paramJSON.keys():
+      print('terminology is in the JSON parameterization file') 
+      # if so, parse it and SET  
+      self.terminologyFile = self.paramJSON['terminology']
+      self.setJSONTerminology()
+      
+    else: 
+      self.customLUTInfoIcon.show()
+      self.customLUTInfoIcon.toolTip = 'Using Default Terminology'
+    
+    return 
+  
+  def setJSONTerminology(self):
+    """Set the terminology parsed from the json file"""
+    
+    self.customLUTInfoIcon.show()
+    self.customLUTInfoIcon.toolTip = 'Using Project-specific Terminology'
+
+    tlogic = slicer.modules.terminologies.logic()
+    self.terminologyName = tlogic.LoadTerminologyFromFile(self.terminologyFile)
+
+    # Set the first entry in this terminology as the default so that when the user
+    # opens the terminoogy selector, the correct list is shown.
+    terminologyEntry = slicer.vtkSlicerTerminologyEntry()
+    terminologyEntry.SetTerminologyContextName(self.terminologyName)
+    tlogic.GetNthCategoryInTerminology(self.terminologyName, 0, terminologyEntry.GetCategoryObject())
+    tlogic.GetNthTypeInTerminologyCategory(self.terminologyName, terminologyEntry.GetCategoryObject(), 0, terminologyEntry.GetTypeObject())
+    defaultTerminologyEntry = tlogic.SerializeTerminologyEntry(terminologyEntry)
+    self.editorWidget.defaultTerminologyEntry = defaultTerminologyEntry
+    
+    # self.editorWidget.setDefaultTerminologyEntrySettingsKey(self.editorWidget.defaultTerminologyEntry)
+
+    self.structureNames = []
+    numberOfTerminologyTypes = tlogic.GetNumberOfTypesInTerminologyCategory(self.terminologyName, terminologyEntry.GetCategoryObject())
+    for terminologyTypeIndex in range(numberOfTerminologyTypes):
+      tlogic.GetNthTypeInTerminologyCategory(self.terminologyName, terminologyEntry.GetCategoryObject(), terminologyTypeIndex, terminologyEntry.GetTypeObject())
+      self.structureNames.append(terminologyEntry.GetTypeObject().GetCodeMeaning())
+
+    return 
+  
+
 
 class mpReviewLogic(ScriptedLoadableModuleLogic):
   """This class should implement all the actual


### PR DESCRIPTION
This is a draft PR of the `multiple_server_feature_json` branch that uses a json parameterization file for local, remote gcp, and other server database options (e.g. kaapana). 

Sample configuration json files are in the "Resources" directory. 

I have implemented the following so far: 
- Local: 
   - With a local configuration (Slicer DICOM database), all studies/series will be loaded into the module, and will switch automatically to the "Study selection" tab. 
- Remote GCP: 
   - The button is selected and the project, dataset, and dicomstore fields are immediately populated (minor issue now with dataset/dicomstore showing up blank). The server url is populated, and user must click OK button to move to "Study selection". The study list is populated with the ones specified in the list, the same for the series. Series such as SEG that have a referenced SeriesInstanceUID in the series list are also loaded. If no series are specified in the list, all series are loaded into module.
- Remote other: 
   - The button is selected and the server url populated, and user must click OK button to move to "Study selection". The same logic for the studies/series to load is applied here. 
 
To do: 
- Use a hierarchy of UIDs instead of single lists for study and series 
- Include a json file selection within the "Database selection" tab 
- For later, include selection of PatientID before study/series 